### PR TITLE
chore: migrate matchPackagePatterns to matchPackageNames

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchPackagePatterns": ["@nrfcloud/*"],
+      "matchPackageNames": ["@nrfcloud/**"],
       "minimumReleaseAge": null
     }
   ]


### PR DESCRIPTION
The `matchPackagePatterns` config is deprecated in Renovate. This PR migrates each occurrence to `matchPackageNames`, using glob syntax (`@scope/**`) for wildcards.

See: https://docs.renovatebot.com/configuration-options/#matchpackagenames

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change to Renovate dependency matching; no runtime code paths are affected.
> 
> **Overview**
> Updates `renovate.json` to replace deprecated `matchPackagePatterns` with `matchPackageNames` using glob syntax (`@nrfcloud/**`) for scoped package matching, keeping the existing rule behavior and `minimumReleaseAge` override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6661dc8f9ad0bba60ae005adfc84fbb5de16885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->