### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nRFCloud/pizza


### PR DESCRIPTION
https://nordicsemi.atlassian.net/wiki/x/94HKq mandates PR reviews for production repositories. Adding a CODEOWNERS file to automatically request reviews from members of the Pizza team.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds metadata for GitHub review assignment only, with no runtime or production code impact.
> 
> **Overview**
> Adds a `CODEOWNERS` file with a single catch-all rule (`* @nRFCloud/pizza`) to automatically assign the Pizza team as reviewers for all pull requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0edd775373a8dddadd4a62a1ca76d132d68993ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->