### PR TITLE
docs: properly name the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@nrfcloud/aws-iam-authenticated-api-gateway-fetch",
   "version": "0.0.0-development",
   "description": "Helper function to use fetch against IAM authenticated APIs.",
-  "homepage": "https://github.com/nrfcloud/aws-iam-authenticated-api-gateway-fetch#readme",
+  "homepage": "https://github.com/nRFCloud/aws-iam-authenticated-api-gateway-fetch#readme",
   "bugs": {
-    "url": "https://github.com/nrfcloud/aws-iam-authenticated-api-gateway-fetch/issues"
+    "url": "https://github.com/nRFCloud/aws-iam-authenticated-api-gateway-fetch/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrfcloud/aws-iam-authenticated-api-gateway-fetch.git"
+    "url": "git+https://github.com/nRFCloud/aws-iam-authenticated-api-gateway-fetch.git"
   },
   "author": "Nordic Semiconductor ASA | nordicsemi.no",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Corrects the casing of the organization name in the `homepage`, `bugs.url` and
`repository.url` fields, from `nrfcloud` to `nRFCloud`.

This is needed for NPM trusted publishing to work, which matches the repository
owner and name case-sensitively.

Same change as
[nRFCloud/problem-detail@61646f1](https://github.com/nRFCloud/problem-detail/commit/61646f101883d4633489d2d8a47f0335610bb628).
