### PR TITLE
chore: do not ignore errors when clearing the npm/ output directory

### DIFF
--- a/.npm/compile.ts
+++ b/.npm/compile.ts
@@ -14,11 +14,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const outDir = path.join(__dirname, '..', 'npm')
 
-try {
-	rmSync(outDir, { recursive: true, force: true })
-} catch {
-	// pass
-}
+rmSync(outDir, { recursive: true, force: true })
 
 for await (const file of glob(
 	tsconfig.include.map((include) => path.join('.npm', include)),


### PR DESCRIPTION
`rmSync` already ignores a missing directory via `force: true`, so the `try`/`catch` only swallowed real errors such as `EACCES` or `EBUSY`. Since `package.json` ships the entire `npm/` folder, a partially cleared output directory meant stale JavaScript from earlier builds could be published.

Ports https://github.com/nRFCloud/wait-for-it/commit/d1060ed6a1ba0f1d194f00e55e0edac0305629d7 to this repository.
